### PR TITLE
Completed funcNameFromRelPathDefault

### DIFF
--- a/src/export-functions.ts
+++ b/src/export-functions.ts
@@ -11,12 +11,14 @@ function getDirnameFromFilename(__filename: string) {
 export function funcNameFromRelPathDefault(relPath: string): string {
   const relPathArray = relPath.split(sep); /* ? */
   const fileName = relPathArray.pop(); /* ? */
-  const relDirPathFunctionNameChunk = relPathArray.map((pathFragment) => camelCase(pathFragment)).join(sep);
-  const fileNameFunctionNameChunk = camelCase(fileName!.split('.')[0]);
+  const relDirPathFunctionNameChunk = relPathArray
+    .map((pathFragment) => camelCase(pathFragment))
+    .join("-");
+  const fileNameFunctionNameChunk = camelCase(fileName!.split(".")[0]);
   const funcName = relDirPathFunctionNameChunk
-    ? `${relDirPathFunctionNameChunk}${sep}${fileNameFunctionNameChunk}`
+    ? `${relDirPathFunctionNameChunk}-${fileNameFunctionNameChunk}`
     : fileNameFunctionNameChunk;
-  return funcName.replace(sep, '-');
+  return funcName;
 }
 
 /**

--- a/src/export-functions.ts
+++ b/src/export-functions.ts
@@ -190,7 +190,7 @@ export function exportFunctions({
   for (const file of files) {
     const absPath = resolve(cwd, file);
     const standardRelativePath = absPath.substr(cwd.length + 1); /* ? */
-    const funcName = funcNameFromRelPath(standardRelativePath); /* ? */
+    const funcName = funcNameFromRelPathDefault(standardRelativePath); /* ? */
     if (isDeployment() || funcNameMatchesInstance(funcName)) {
       if (!isDeployment()) log.timeEnd(moduleSearchMsg);
       if (absPath.slice(0, -2) === __filename.slice(0, -2)) continue; // Prevent exporting self

--- a/src/export-functions.ts
+++ b/src/export-functions.ts
@@ -190,7 +190,7 @@ export function exportFunctions({
   for (const file of files) {
     const absPath = resolve(cwd, file);
     const standardRelativePath = absPath.substr(cwd.length + 1); /* ? */
-    const funcName = funcNameFromRelPathDefault(standardRelativePath); /* ? */
+    const funcName = funcNameFromRelPath(standardRelativePath); /* ? */
     if (isDeployment() || funcNameMatchesInstance(funcName)) {
       if (!isDeployment()) log.timeEnd(moduleSearchMsg);
       if (absPath.slice(0, -2) === __filename.slice(0, -2)) continue; // Prevent exporting self


### PR DESCRIPTION
One issue, one style; both resolved by simplifying code:
Issue: the last replace, because it was a value not a regex, only replaced the first instance

Style: the string was already split; why .join(sep) only to .replace(`/${sep}/g, "-") later?

SO: split, then join("-"), then no need to replace.

Ran what tests I could (apparently don't have the *full* sample/test environment), but also tested "in the field" (emulator and deploy).

````
export function funcNameFromRelPathDefault(relPath: string): string {
  const relPathArray = relPath.split(sep); /* ? */
  const fileName = relPathArray.pop(); /* ? */
  const relDirPathFunctionNameChunk = relPathArray
    .map((pathFragment) => camelCase(pathFragment))
    .join("-");
  const fileNameFunctionNameChunk = camelCase(fileName!.split(".")[0]);
  const funcName = relDirPathFunctionNameChunk
    ? `${relDirPathFunctionNameChunk}-${fileNameFunctionNameChunk}`
    : fileNameFunctionNameChunk;
  return funcName;
}
```