### PR TITLE
build(package.json): update deprecated @zeit/ncc package to @vercel/ncc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/tmp": "^0.2.3",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
-        "@zeit/ncc": "^0.22.3",
+        "@vercel/ncc": "^0.36.0",
         "camelcase": "^6.3.0",
         "commitizen": "^4.2.4",
         "cz-conventional-changelog": "^3.3.0",
@@ -2920,11 +2920,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -16453,10 +16452,10 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
-    "@zeit/ncc": "^0.22.3",
+    "@vercel/ncc": "^0.36.0",
     "camelcase": "^6.3.0",
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
I am using node v18.12.1. 

The @zeit/ncc caused the build to fail. 

After changing to @vercel/ncc that never happened.

```
> better-firebase-functions@4.0.0 build
> rm -rf ./lib/  && ncc build src/index.ts -o lib/ -m && tsc -d --declarationDir lib/types --emitDeclarationOnly

ncc: Version 0.22.3
ncc: Compiling file index.js
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at hashOf (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:3:58216)
    at module.exports (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:3:60642)
    at runCmd (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:47355)
    at 819 (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:44227)
    at __webpack_require__ (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:169)
    at startup (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:339)
    at module.exports.8 (/web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:371)
    at /web/better-firebase-functions/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:381 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```